### PR TITLE
multi-GPU training will crash due to wandb logging image on another rank

### DIFF
--- a/unitraj/models/base_model/base_model.py
+++ b/unitraj/models/base_model/base_model.py
@@ -262,9 +262,8 @@ class BaseModel(pl.LightningModule):
         for k, v in loss_dict.items():
             self.log(status + "/" + k, v, on_step=False, on_epoch=True, sync_dist=True, batch_size=size_dict[k])
 
-        if status == 'val' and batch_idx == 0 and not self.config.debug:
+        if self.local_rank == 0 and status == 'val' and batch_idx == 0:
             img = visualization.visualize_prediction(batch, prediction)
-            if self.local_rank == 0:
-                wandb.log({"prediction": [wandb.Image(img)]})
+            wandb.log({"prediction": [wandb.Image(img)]})
 
         return

--- a/unitraj/models/base_model/base_model.py
+++ b/unitraj/models/base_model/base_model.py
@@ -264,6 +264,7 @@ class BaseModel(pl.LightningModule):
 
         if status == 'val' and batch_idx == 0 and not self.config.debug:
             img = visualization.visualize_prediction(batch, prediction)
-            wandb.log({"prediction": [wandb.Image(img)]})
+            if self.local_rank == 0:
+                wandb.log({"prediction": [wandb.Image(img)]})
 
         return


### PR DESCRIPTION
Keep every other arguments the same but switch from single gpu to multi-gpu will trigger the following issue:

```
  File "/home/hyuyao/2024/trackpred_v2/shared_libs/3rd_party/UniTraj/unitraj/models/base_model/base_model.py", line 60, in validation_step 
    self.log_info(batch, batch_idx, prediction, status='val')                                                                              
  File "/home/hyuyao/2024/trackpred_v2/shared_libs/3rd_party/UniTraj/unitraj/models/base_model/base_model.py", line 267, in log_info       
    wandb.log({"prediction": [wandb.Image(img)]})                                                                                          
  File "/home/hyuyao/miniconda3/envs/unitraj/lib/python3.11/site-packages/wandb/sdk/lib/preinit.py", line 36, in preinit_wrapper           
    raise wandb.Error(f"You must call wandb.init() before {name}()")                                                                       
wandb.errors.Error: You must call wandb.init() before wandb.log()                                                                          

```

I am not sure if this PR is the best way to fix this issue but it works for me.