### PR TITLE
update base_model to remove incorrect eval on training set

### DIFF
--- a/unitraj/models/base_model/base_model.py
+++ b/unitraj/models/base_model/base_model.py
@@ -50,7 +50,6 @@ class BaseModel(pl.LightningModule):
 
     def training_step(self, batch, batch_idx):
         prediction, loss = self.forward(batch)
-        self.compute_official_evaluation(batch, prediction)
         self.log_info(batch, batch_idx, prediction, status='train')
         return loss
 


### PR DESCRIPTION
### Description
There is an error in base_model that causes incorrect evaluation of the training set.
```
    def training_step(self, batch, batch_idx):
        prediction, loss = self.forward(batch)
        self.compute_official_evaluation(batch, prediction) # PROBLEM
        self.log_info(batch, batch_idx, prediction, status='train')
        return loss
```
This bug may incur error for models with different numbers of mode between training and evaluation, e.g., MTR.
In this PR, I remove this line of code.