### PR TITLE
Update cache loading logic to check file existence before use 

### DIFF
--- a/unitraj/datasets/base_dataset.py
+++ b/unitraj/datasets/base_dataset.py
@@ -49,7 +49,7 @@ class BaseDataset(Dataset):
 
             data_usage_this_dataset = self.config['max_data_num'][cnt]
             self.starting_frame = self.config['starting_frame'][cnt]
-            if self.config['use_cache'] or is_ddp():
+            if (self.config['use_cache'] or is_ddp()) and os.path.exists(self.cache_path):
                 file_list = self.get_data_list(data_usage_this_dataset)
             else:
                 if os.path.exists(self.cache_path) and self.config.get('overwrite_cache', False) is False:


### PR DESCRIPTION
Previously, the code would automatically attempt to use cache files in DDP mode (when is_ddp() returns True), which is detected by the presence of WORLD_SIZE environment variable set by torchrun. This caused failures when running with torchrun without existing cache files, as the program would try to load non-existent cache files.

With this change, cache usage is now solely determined by the use_cache configuration parameter, regardless of whether the code is running in DDP mode or not. This ensures that:
1. When use_cache=False, cache files will not be used even in DDP mode
2. Running with python or torchrun will have consistent behavior

This prevents torchrun from failing when cache files are not present, making the cache behavior predictable and controlled by explicit configuration rather than implicit environment variables.